### PR TITLE
Fix bug related to new `basestring` type in cython 0.20

### DIFF
--- a/redshift/sentence.pyx
+++ b/redshift/sentence.pyx
@@ -25,7 +25,7 @@ cdef Sentence* init_sent(list words_lattice, list parse) except NULL:
     for i, (word_idx, tag, head, label, sent_id, is_edit) in enumerate(parse):
         s.tokens[i].word = s.lattice[i].nodes[word_idx]
         if tag is not None:
-            s.tokens[i].tag = index.hashes.encode_pos(tag) 
+            s.tokens[i].tag = index.hashes.encode_pos(tag)
         if head is not None:
             s.tokens[i].head = head if head != 0 else s.n - 1
         if label is not None:
@@ -132,7 +132,7 @@ cdef class Input:
             is_edit = len(feats) >= 3 and feats[2] == '1'
             #if len(feats) >= 5 and feats[4] == 'RM':
             #    is_edit = True
-            is_fill = len(feats) >= 2 and feats[1] in ('D', 'E', 'F', 'A') 
+            is_fill = len(feats) >= 2 and feats[1] in ('D', 'E', 'F', 'A')
             is_ns = len(feats) >= 4 and feats[3] == 'N_S'
             is_ns = False
             sent_id = int(feats[0].split('.')[1]) if '.' in feats[0] else 0
@@ -248,5 +248,5 @@ cdef bytes conll_line_from_token(size_t i, Token* a, Step* lattice):
     fill_tag = label[-1] if label.startswith('filler') else '-'
     feats = '0.%d|%s|%d|-' % (a.sent_id, fill_tag, label == 'erased')
     cdef bytes tag = index.hashes.decode_pos(a.tag)
-    return '\t'.join((str(i), word, '_', tag, tag, feats, 
-                     str(a.head), label, '_', '_'))
+    return <bytes>'\t'.join((str(i), word, '_', tag, tag, feats,
+                             str(a.head), label, '_', '_'))


### PR DESCRIPTION
In particular:
`redshift/sentence.pyx:251:20: Cannot convert 'basestring' object to bytes
implicitly. This is not portable.`
